### PR TITLE
Fix tests with Twisted trunk

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Contributor Guide
+
+Synapse is a Python application that has Rust modules via pyo3 for performance.
+
+## Dev Environment Tips
+- Source code is primarily in `synapse/`, tests are in `tests/`.
+- Run `poetry install --dev` to install development python dependencies. This will also build and install the Synapse rust code.
+- Use `./scripts-dev/lint.sh` to lint the codebase (this attempts to fix issues as well). This should be run and produce no errors before every commit.
+
+## Testing Instructions
+- Find the CI plan in the .github/workflows folder.
+- Use `poetry run trial tests` to run all unit tests, or `poetry run trial tests.metrics.test_phone_home_stats.PhoneHomeStatsTestCase` (for example) to run a single test case. The commit should pass all tests before you merge.
+- Some typing warnings are expected currently. Fix any test or type *errors* until the whole suite is green.
+- Add or update relevant tests for the code you change, even if nobody asked.

--- a/tests/http/federation/test_matrix_federation_agent.py
+++ b/tests/http/federation/test_matrix_federation_agent.py
@@ -84,6 +84,15 @@ class MatrixFederationAgentTests(unittest.TestCase):
 
         self.tls_factory = FederationPolicyForHTTPS(config)
 
+        # ensure any proxy settings from the environment do not interfere with
+        # the tests. In some execution environments (like CI or the test
+        # runner's container) `https_proxy` or `http_proxy` may be preset which
+        # would cause the agent to attempt to proxy outbound connections.
+        for var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+            if var in os.environ:
+                old = os.environ.pop(var)
+                self.addCleanup(os.environ.__setitem__, var, old)
+
         self.well_known_cache: TTLCache[bytes, Optional[bytes]] = TTLCache(
             "test_cache", timer=self.reactor.seconds
         )


### PR DESCRIPTION
## Summary
- clean proxy variables in MatrixFederationAgentTests

## Testing
- `poetry run ./scripts-dev/lint.sh -d tests/http/federation/test_matrix_federation_agent.py`
- `poetry run trial tests.http.federation.test_matrix_federation_agent.MatrixFederationAgentTests.test_get_hostname_bad_cert`


------
https://chatgpt.com/codex/tasks/task_e_6840e035178c833180d03fb87db9a9ad