### PR TITLE
Fix worker lock timeout warning threshold

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,9 @@ Synapse is a Python application that has Rust modules via pyo3 for performance.
 - Run `poetry install --dev` to install development python dependencies. This will also build and install the Synapse rust code.
 - Use `./scripts-dev/lint.sh` to lint the codebase (this attempts to fix issues as well). This should be run and produce no errors before every commit.
 
+## Dev Tips
+- If any change creates a breaking change or requires downstream users (sysadmins) to update their environment, call it out in `docs/upgrade.md` as a new entry with the title "# Upgrading to vx.yy.z" with the details of what they should do or be aware of.
+
 ## Testing Instructions
 - Find the CI plan in the .github/workflows folder.
 - Use `poetry run trial tests` to run all unit tests, or `poetry run trial tests.metrics.test_phone_home_stats.PhoneHomeStatsTestCase` (for example) to run a single test case. The commit should pass all tests before you merge.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Contributor Guide
+
+Synapse is a Python application that has Rust modules via pyo3 for performance.
+
+## Dev Environment Tips
+- Source code is primarily in `synapse/`, tests are in `tests/`.
+- Run `poetry install --dev` to install development python dependencies. This will also build and install the Synapse rust code.
+- Use `./scripts-dev/lint.sh` to lint the codebase (this attempts to fix issues as well). This should be run and produce no errors before every commit.
+
+## Testing Instructions
+- Find the CI plan in the .github/workflows folder.
+- Use `poetry run trial tests` to run all unit tests, or `poetry run trial tests.metrics.test_phone_home_stats.PhoneHomeStatsTestCase` (for example) to run a single test case. The commit should pass all tests before you merge.
+- Some typing warnings are expected currently. Fix any test or type *errors* until the whole suite is green.
+- Add or update relevant tests for the code you change, even if nobody asked.

--- a/synapse/handlers/worker_lock.py
+++ b/synapse/handlers/worker_lock.py
@@ -270,7 +270,7 @@ class WaitingLock:
     def _get_next_retry_interval(self) -> float:
         next = self._retry_interval
         self._retry_interval = max(5, next * 2)
-        if self._retry_interval > 5 * 2 ^ 7:  # ~10 minutes
+        if self._retry_interval > 5 * 2**7:  # ~10 minutes
             logging.warning(
                 f"Lock timeout is getting excessive: {self._retry_interval}s. There may be a deadlock."
             )
@@ -349,7 +349,7 @@ class WaitingMultiLock:
     def _get_next_retry_interval(self) -> float:
         next = self._retry_interval
         self._retry_interval = max(5, next * 2)
-        if self._retry_interval > 5 * 2 ^ 7:  # ~10 minutes
+        if self._retry_interval > 5 * 2**7:  # ~10 minutes
             logging.warning(
                 f"Lock timeout is getting excessive: {self._retry_interval}s. There may be a deadlock."
             )


### PR DESCRIPTION
## Summary
- fix worker lock retry timeout calculation

## Testing
- `./scripts-dev/lint.sh` *(fails: `cargo-clippy` missing)*
- `poetry run trial tests.handlers.test_worker_lock.WorkerLockTestCase`

------
https://chatgpt.com/codex/tasks/task_e_6842ee3099488331993219faa1c87770