### PR TITLE
Fix mypy errors with Twisted 25.5

### DIFF
--- a/synapse/http/proxyagent.py
+++ b/synapse/http/proxyagent.py
@@ -21,7 +21,7 @@
 import logging
 import random
 import re
-from typing import Any, Collection, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Collection, Dict, List, Optional, Sequence, Tuple, Union, cast
 from urllib.parse import urlparse
 from urllib.request import (  # type: ignore[attr-defined]
     getproxies_environment,
@@ -40,6 +40,7 @@ from twisted.internet.interfaces import (
     IProtocol,
     IProtocolFactory,
     IReactorCore,
+    IReactorTime,
     IStreamClientEndpoint,
 )
 from twisted.python.failure import Failure
@@ -129,7 +130,9 @@ class ProxyAgent(_AgentBase):
     ):
         contextFactory = contextFactory or BrowserLikePolicyForHTTPS()
 
-        _AgentBase.__init__(self, reactor, pool)
+        # `_AgentBase` expects an `IReactorTime` provider. `IReactorCore`
+        # extends `IReactorTime`, so this cast is safe.
+        _AgentBase.__init__(self, cast(IReactorTime, reactor), pool)
 
         if proxy_reactor is None:
             self.proxy_reactor = reactor
@@ -168,7 +171,7 @@ class ProxyAgent(_AgentBase):
         self.no_proxy = no_proxy
 
         self._policy_for_https = contextFactory
-        self._reactor = reactor
+        self._reactor = cast(IReactorTime, reactor)
 
         self._federation_proxy_endpoint: Optional[IStreamClientEndpoint] = None
         self._federation_proxy_credentials: Optional[ProxyCredentials] = None
@@ -257,7 +260,11 @@ class ProxyAgent(_AgentBase):
             raise ValueError(f"Invalid URI {uri!r}")
 
         parsed_uri = URI.fromBytes(uri)
-        pool_key = f"{parsed_uri.scheme!r}{parsed_uri.host!r}{parsed_uri.port}"
+        pool_key: tuple[bytes, bytes, int] = (
+            parsed_uri.scheme,
+            parsed_uri.host,
+            parsed_uri.port,
+        )
         request_path = parsed_uri.originForm
 
         should_skip_proxy = False
@@ -283,7 +290,7 @@ class ProxyAgent(_AgentBase):
                 )
             # Cache *all* connections under the same key, since we are only
             # connecting to a single destination, the proxy:
-            pool_key = "http-proxy"
+            pool_key = (b"http-proxy", b"", 0)
             endpoint = self.http_proxy_endpoint
             request_path = uri
         elif (

--- a/synapse/http/replicationagent.py
+++ b/synapse/http/replicationagent.py
@@ -180,9 +180,16 @@ class ReplicationAgent(_AgentBase):
         worker_name = parsedURI.netloc.decode("utf-8")
         key_scheme = self._endpointFactory.instance_map[worker_name].scheme()
         key_netloc = self._endpointFactory.instance_map[worker_name].netloc()
-        # This sets the Pool key to be:
-        #  (http(s), <host:port>) or (unix, <socket_path>)
-        key = (key_scheme, key_netloc)
+        # Build a connection pool key.
+        #
+        # `_AgentBase` expects this to be a three-tuple of `(scheme, host,
+        # port)` of type `bytes`. We don't have a real port when connecting via
+        # a Unix socket, so use `0`.
+        key = (
+            key_scheme.encode("ascii"),
+            key_netloc.encode("utf-8"),
+            0,
+        )
 
         # _requestWithEndpoint comes from _AgentBase class
         return self._requestWithEndpoint(

--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -497,7 +497,7 @@ class JsonResource(DirectServeJsonResource):
             key word arguments to pass to the callback
         """
         # At this point the path must be bytes.
-        request_path_bytes: bytes = request.path  # type: ignore
+        request_path_bytes: bytes = request.path
         request_path = request_path_bytes.decode("ascii")
         # Treat HEAD requests as GET requests.
         request_method = request.method

--- a/tests/logging/test_terse_json.py
+++ b/tests/logging/test_terse_json.py
@@ -160,7 +160,14 @@ class TerseJsonTestCase(LoggerCleanupMixin, TestCase):
         logger = self.get_logger(handler)
 
         # A full request isn't needed here.
-        site = Mock(spec=["site_tag", "server_version_string", "getResourceFor"])
+        site = Mock(
+            spec=[
+                "site_tag",
+                "server_version_string",
+                "getResourceFor",
+                "_parsePOSTFormSubmission",
+            ]
+        )
         site.site_tag = "test-site"
         site.server_version_string = "Server v1"
         site.reactor = Mock()

--- a/tests/replication/_base.py
+++ b/tests/replication/_base.py
@@ -220,7 +220,7 @@ class BaseStreamTestCase(unittest.HomeserverTestCase):
         fetching updates for given stream.
         """
 
-        path: bytes = request.path  # type: ignore
+        path: bytes = request.path
         self.assertRegex(
             path,
             rb"^/_synapse/replication/get_repl_stream_updates/%s/[^/]+$"

--- a/tests/server.py
+++ b/tests/server.py
@@ -517,8 +517,12 @@ class ThreadedMemoryReactorClock(MemoryReactorClock):
 
             tls._get_default_clock = lambda: self
 
-        self.nameResolver = SimpleResolverComplexifier(FakeResolver())
         super().__init__()
+
+        # Override the default name resolver with our fake resolver. This must
+        # happen after `super().__init__()` so that the base class doesn't
+        # overwrite it again.
+        self.nameResolver = SimpleResolverComplexifier(FakeResolver())
 
     def installNameResolver(self, resolver: IHostnameResolver) -> IHostnameResolver:
         raise NotImplementedError()

--- a/tests/storage/databases/main/test_events_worker.py
+++ b/tests/storage/databases/main/test_events_worker.py
@@ -449,24 +449,27 @@ class DatabaseOutageTestCase(unittest.HomeserverTestCase):
 
     def test_recovery(self) -> None:
         """Test that event fetchers recover after a database outage."""
-        with self._outage():
-            # Kick off a bunch of event fetches but do not pump the reactor
-            event_deferreds = []
-            for event_id in self.event_ids:
-                event_deferreds.append(ensureDeferred(self.store.get_event(event_id)))
+        with self.assertLogs(
+            "synapse.metrics.background_process_metrics", level="ERROR"
+        ):
+            with self._outage():
+                # Kick off a bunch of event fetches but do not pump the reactor
+                event_deferreds = []
+                for event_id in self.event_ids:
+                    event_deferreds.append(ensureDeferred(self.store.get_event(event_id)))
 
-            # We should have maxed out on event fetcher threads
-            self.assertEqual(self.store._event_fetch_ongoing, EVENT_QUEUE_THREADS)
+                # We should have maxed out on event fetcher threads
+                self.assertEqual(self.store._event_fetch_ongoing, EVENT_QUEUE_THREADS)
 
-            # All the event fetchers will fail
-            self.pump()
-            self.assertEqual(self.store._event_fetch_ongoing, 0)
+                # All the event fetchers will fail
+                self.pump()
+                self.assertEqual(self.store._event_fetch_ongoing, 0)
 
-            for event_deferred in event_deferreds:
-                failure = self.get_failure(event_deferred, Exception)
-                self.assertEqual(
-                    str(failure.value), "Could not connect to the database."
-                )
+                for event_deferred in event_deferreds:
+                    failure = self.get_failure(event_deferred, Exception)
+                    self.assertEqual(
+                        str(failure.value), "Could not connect to the database."
+                    )
 
         # This next event fetch should succeed
         self.get_success(self.store.get_event(self.event_ids[0]))

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -226,8 +226,7 @@ class OptionsResourceTests(unittest.TestCase):
             isLeaf = True
 
             def render(self, request: SynapseRequest) -> bytes:
-                # Type-ignore: mypy thinks request.path is Optional[Any], not bytes.
-                return request.path  # type: ignore[return-value]
+                return request.path
 
         # Setup a resource with some children.
         self.resource = OptionsResource()


### PR DESCRIPTION
## Summary
- fix request key types for ReplicationAgent
- update ProxyAgent reactor types and pool keys
- drop obsolete ignores and fix custom reactor resolver

## Testing
- `ruff check synapse/http/replicationagent.py synapse/http/proxyagent.py synapse/http/server.py tests/server.py tests/replication/_base.py tests/test_server.py`
- `poetry run mypy`
- `HTTP_PROXY= HTTPS_PROXY= http_proxy= https_proxy= no_proxy= NO_PROXY= poetry run trial tests.http.federation.test_matrix_federation_agent.MatrixFederationAgentTests.test_get`

------
https://chatgpt.com/codex/tasks/task_e_68554ad84e2083318845367628e25869