### PR TITLE
refactor: replace pkg_resources usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Contributor Guide
+
+Synapse is a Python application that has Rust modules via pyo3 for performance.
+
+## Dev Environment Tips
+- Source code is primarily in `synapse/`, tests are in `tests/`.
+- Run `poetry install --dev` to install development python dependencies. This will also build and install the Synapse rust code.
+- Use `./scripts-dev/lint.sh` to lint the codebase (this attempts to fix issues as well). This should be run and produce no errors before every commit.
+
+## Dev Tips
+- If any change creates a breaking change or requires downstream users (sysadmins) to update their environment, call it out in `docs/upgrade.md` as a new entry with the title "# Upgrading to vx.yy.z" with the details of what they should do or be aware of.
+- All code comments and documentation should be written in Markdown, NOT RST.
+
+## Testing Instructions
+- Find the CI plan in the .github/workflows folder.
+- Use `poetry run trial tests` to run all unit tests, or `poetry run trial tests.metrics.test_phone_home_stats.PhoneHomeStatsTestCase` (for example) to run a single test case. The commit should pass all tests before you merge.
+- Some typing warnings are expected currently. Fix any test or type *errors* until the whole suite is green.
+- Add or update relevant tests for the code you change, even if nobody asked.
+

--- a/synapse/config/_base.py
+++ b/synapse/config/_base.py
@@ -22,6 +22,7 @@
 
 import argparse
 import errno
+import importlib.resources as importlib_resources
 import logging
 import os
 import re
@@ -46,7 +47,6 @@ from typing import (
 
 import attr
 import jinja2
-import pkg_resources
 import yaml
 
 from synapse.types import StrSequence
@@ -174,8 +174,8 @@ class Config:
         self.root = root_config
 
         # Get the path to the default Synapse template directory
-        self.default_template_dir = pkg_resources.resource_filename(
-            "synapse", "res/templates"
+        self.default_template_dir = str(
+            importlib_resources.files("synapse").joinpath("res", "templates")
         )
 
     @staticmethod

--- a/synapse/config/oembed.py
+++ b/synapse/config/oembed.py
@@ -18,13 +18,13 @@
 # [This file includes modifications made by New Vector Limited]
 #
 #
+import importlib.resources as importlib_resources
 import json
 import re
 from typing import Any, Dict, Iterable, List, Optional, Pattern
 from urllib import parse as urlparse
 
 import attr
-import pkg_resources
 
 from synapse.types import JsonDict, StrSequence
 
@@ -64,7 +64,10 @@ class OembedConfig(Config):
         """
         # Whether to use the packaged providers.json file.
         if not oembed_config.get("disable_default_providers") or False:
-            with pkg_resources.resource_stream("synapse", "res/providers.json") as s:
+            path = importlib_resources.files("synapse").joinpath(
+                "res", "providers.json"
+            )
+            with path.open("rt") as s:
                 providers = json.load(s)
 
             yield from self._parse_and_validate_provider(

--- a/synapse/config/oembed.py
+++ b/synapse/config/oembed.py
@@ -64,10 +64,12 @@ class OembedConfig(Config):
         """
         # Whether to use the packaged providers.json file.
         if not oembed_config.get("disable_default_providers") or False:
-            path = importlib_resources.files("synapse").joinpath(
-                "res", "providers.json"
+            path = (
+                importlib_resources.files("synapse")
+                .joinpath("res")
+                .joinpath("providers.json")
             )
-            with path.open("rt") as s:
+            with path.open("r", encoding="utf-8") as s:
                 providers = json.load(s)
 
             yield from self._parse_and_validate_provider(

--- a/synapse/metrics/__init__.py
+++ b/synapse/metrics/__init__.py
@@ -43,7 +43,7 @@ from typing import (
 )
 
 import attr
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 from prometheus_client import (
     CollectorRegistry,
     Counter,

--- a/tests/push/test_email.py
+++ b/tests/push/test_email.py
@@ -59,11 +59,12 @@ class EmailPusherTests(HomeserverTestCase):
 
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         config = self.default_config()
+        templates = (
+            importlib_resources.files("synapse").joinpath("res").joinpath("templates")
+        )
         config["email"] = {
             "enable_notifs": True,
-            "template_dir": os.path.abspath(
-                importlib_resources.files("synapse").joinpath("res", "templates")
-            ),
+            "template_dir": os.path.abspath(str(templates)),
             "expiry_template_html": "notice_expiry.html",
             "expiry_template_text": "notice_expiry.txt",
             "notif_template_html": "notif_mail.html",

--- a/tests/push/test_email.py
+++ b/tests/push/test_email.py
@@ -18,12 +18,12 @@
 #
 #
 import email.message
+import importlib.resources as importlib_resources
 import os
 from http import HTTPStatus
 from typing import Any, Dict, List, Sequence, Tuple
 
 import attr
-import pkg_resources
 from parameterized import parameterized
 
 from twisted.internet.defer import Deferred
@@ -62,7 +62,7 @@ class EmailPusherTests(HomeserverTestCase):
         config["email"] = {
             "enable_notifs": True,
             "template_dir": os.path.abspath(
-                pkg_resources.resource_filename("synapse", "res/templates")
+                importlib_resources.files("synapse").joinpath("res", "templates")
             ),
             "expiry_template_html": "notice_expiry.html",
             "expiry_template_text": "notice_expiry.txt",

--- a/tests/rest/client/test_account.py
+++ b/tests/rest/client/test_account.py
@@ -58,11 +58,12 @@ class PasswordResetTestCase(unittest.HomeserverTestCase):
         config = self.default_config()
 
         # Email config.
+        templates = (
+            importlib_resources.files("synapse").joinpath("res").joinpath("templates")
+        )
         config["email"] = {
             "enable_notifs": False,
-            "template_dir": os.path.abspath(
-                importlib_resources.files("synapse").joinpath("res", "templates")
-            ),
+            "template_dir": os.path.abspath(str(templates)),
             "smtp_host": "127.0.0.1",
             "smtp_port": 20,
             "require_transport_security": False,
@@ -797,11 +798,12 @@ class ThreepidEmailRestTestCase(unittest.HomeserverTestCase):
         config = self.default_config()
 
         # Email config.
+        templates = (
+            importlib_resources.files("synapse").joinpath("res").joinpath("templates")
+        )
         config["email"] = {
             "enable_notifs": False,
-            "template_dir": os.path.abspath(
-                importlib_resources.files("synapse").joinpath("res", "templates")
-            ),
+            "template_dir": os.path.abspath(str(templates)),
             "smtp_host": "127.0.0.1",
             "smtp_port": 20,
             "require_transport_security": False,

--- a/tests/rest/client/test_account.py
+++ b/tests/rest/client/test_account.py
@@ -18,14 +18,13 @@
 # [This file includes modifications made by New Vector Limited]
 #
 #
+import importlib.resources as importlib_resources
 import os
 import re
 from email.parser import Parser
 from http import HTTPStatus
 from typing import Any, Dict, List, Optional, Union
 from unittest.mock import Mock
-
-import pkg_resources
 
 from twisted.internet.interfaces import IReactorTCP
 from twisted.internet.testing import MemoryReactor
@@ -62,7 +61,7 @@ class PasswordResetTestCase(unittest.HomeserverTestCase):
         config["email"] = {
             "enable_notifs": False,
             "template_dir": os.path.abspath(
-                pkg_resources.resource_filename("synapse", "res/templates")
+                importlib_resources.files("synapse").joinpath("res", "templates")
             ),
             "smtp_host": "127.0.0.1",
             "smtp_port": 20,
@@ -801,7 +800,7 @@ class ThreepidEmailRestTestCase(unittest.HomeserverTestCase):
         config["email"] = {
             "enable_notifs": False,
             "template_dir": os.path.abspath(
-                pkg_resources.resource_filename("synapse", "res/templates")
+                importlib_resources.files("synapse").joinpath("res", "templates")
             ),
             "smtp_host": "127.0.0.1",
             "smtp_port": 20,

--- a/tests/rest/client/test_register.py
+++ b/tests/rest/client/test_register.py
@@ -20,11 +20,10 @@
 #
 #
 import datetime
+import importlib.resources as importlib_resources
 import os
 from typing import Any, Dict, List, Tuple
 from unittest.mock import AsyncMock
-
-import pkg_resources
 
 from twisted.internet.testing import MemoryReactor
 
@@ -984,7 +983,7 @@ class AccountValidityRenewalByEmailTestCase(unittest.HomeserverTestCase):
         config["email"] = {
             "enable_notifs": True,
             "template_dir": os.path.abspath(
-                pkg_resources.resource_filename("synapse", "res/templates")
+                importlib_resources.files("synapse").joinpath("res", "templates")
             ),
             "expiry_template_html": "notice_expiry.html",
             "expiry_template_text": "notice_expiry.txt",

--- a/tests/rest/client/test_register.py
+++ b/tests/rest/client/test_register.py
@@ -980,11 +980,12 @@ class AccountValidityRenewalByEmailTestCase(unittest.HomeserverTestCase):
 
         # Email config.
 
+        templates = (
+            importlib_resources.files("synapse").joinpath("res").joinpath("templates")
+        )
         config["email"] = {
             "enable_notifs": True,
-            "template_dir": os.path.abspath(
-                importlib_resources.files("synapse").joinpath("res", "templates")
-            ),
+            "template_dir": os.path.abspath(str(templates)),
             "expiry_template_html": "notice_expiry.html",
             "expiry_template_text": "notice_expiry.txt",
             "notif_template_html": "notif_mail.html",


### PR DESCRIPTION
## Summary
- replace deprecated `pkg_resources` utilities with `importlib.resources`
- use `packaging.version.parse` for comparing prometheus client versions
- update tests to load templates via `importlib.resources`

## Testing
- `poetry run ./scripts-dev/lint.sh` *(fails: Rust module outdated)*
- `poetry run trial tests.push.test_email tests.rest.client.test_account tests.rest.client.test_register tests.metrics tests.config` *(fails: circular import in synapse package)*

------
https://chatgpt.com/codex/tasks/task_e_68c2adf4b5d08331b289cfe047d96a20